### PR TITLE
Some fixes to keep the plugin healthy

### DIFF
--- a/src/SidePanel.ts
+++ b/src/SidePanel.ts
@@ -8,6 +8,7 @@ const GAME_URLS = require('../GAME_URLS.json');
 export default class SidePanel extends ItemView {
 	private readonly endGameButton: HTMLButtonElement = document.createElement("button");
 	private readonly openGameButton: HTMLButtonElement = document.createElement("button");
+	private gameSelect: HTMLSelectElement = document.createElement("select");
 	private gameDiv: HTMLDivElement = document.createElement("div");
 	private dropDownDiv: HTMLDivElement = document.createElement("div");
 
@@ -34,7 +35,7 @@ export default class SidePanel extends ItemView {
 			this.disableButton(this.openGameButton);
 
 			this.gameDiv.appendChild(
-				this.generateGameIFrame()
+				this.generateGameIFrame(this.gameSelect.value)
 			);
 
 			this.enableButton(this.endGameButton);
@@ -45,29 +46,28 @@ export default class SidePanel extends ItemView {
 		const label = document.createElement("label");
 		label.setText("Select Game:");
 
-		const select = document.createElement("select");
-		select.id = "game-select";
-		select.name = "game-select";
+		this.gameSelect.id = "game-select";
+		this.gameSelect.name = "game-select";
 
 		for (const game in GAME_URLS) {
 			const option = document.createElement("option");
 			option.value = game;
 			option.text = game;
-			select.appendChild(option);
+			this.gameSelect.appendChild(option);
 		}
 
-		select.onchange = (_) => {
-			console.debug(`[ObsiDOOM] Selected game: ${select.value}`);
+		this.gameSelect.onchange = (_) => {
+			console.debug(`[ObsiDOOM] Selected game: ${this.gameSelect.value}`);
 			this.gameDiv.children[0].remove();
 			this.disableButton(this.openGameButton);
 			this.gameDiv.appendChild(
-				this.generateGameIFrame(select.value)
+				this.generateGameIFrame(this.gameSelect.value)
 			);
 			this.enableButton(this.endGameButton);
 		}
 
 		this.dropDownDiv.appendChild(label);
-		this.dropDownDiv.appendChild(select);
+		this.dropDownDiv.appendChild(this.gameSelect);
 	}
 
 	/**

--- a/src/SidePanel.ts
+++ b/src/SidePanel.ts
@@ -1,7 +1,7 @@
 import {ItemView, Workspace, WorkspaceLeaf} from "obsidian";
 
 
-export const SIDE_PANEL_ID = "ObsiDOOM Side Panel";
+export const SIDE_PANEL_ID = "obsidoom";
 
 const GAME_URLS = require('../GAME_URLS.json');
 

--- a/src/SidePanel.ts
+++ b/src/SidePanel.ts
@@ -108,11 +108,6 @@ export default class SidePanel extends ItemView {
 
 		const container = this.contentEl;
 
-		const header = document.createElement("h3");
-		header.textContent = "DOOM";
-		header.addClass("doom-header");
-		container.appendChild(header);
-
 		container.appendChild(this.dropDownDiv);
 
 		container.appendChild(this.gameDiv);

--- a/src/SidePanel.ts
+++ b/src/SidePanel.ts
@@ -57,7 +57,6 @@ export default class SidePanel extends ItemView {
 		}
 
 		this.gameSelect.onchange = (_) => {
-			console.debug(`[ObsiDOOM] Selected game: ${this.gameSelect.value}`);
 			this.gameDiv.children[0].remove();
 			this.disableButton(this.openGameButton);
 			this.gameDiv.appendChild(
@@ -104,8 +103,6 @@ export default class SidePanel extends ItemView {
 	 * Set up the HTML of the view
 	 */
 	async onOpen() {
-		console.log("Opened ObsiDOOM Side Panel");
-
 		const container = this.contentEl;
 
 		container.appendChild(this.dropDownDiv);

--- a/src/SidePanel.ts
+++ b/src/SidePanel.ts
@@ -78,7 +78,7 @@ export default class SidePanel extends ItemView {
 	static async activate(workspace: Workspace) {
 		workspace.detachLeavesOfType(SIDE_PANEL_ID);
 
-		await workspace.getRightLeaf(false).setViewState({
+		await workspace.getRightLeaf(false)?.setViewState({
 			type: SIDE_PANEL_ID,
 			active: true,
 		});

--- a/src/SidePanel.ts
+++ b/src/SidePanel.ts
@@ -22,7 +22,7 @@ export default class SidePanel extends ItemView {
 		this.endGameButton.onClickEvent(() => {
 			this.disableButton(this.endGameButton);
 
-			this.gameDiv.children[0].remove();
+			this.gameDiv.firstChild?.remove();
 
 			this.enableButton(this.openGameButton);
 		});
@@ -57,7 +57,7 @@ export default class SidePanel extends ItemView {
 		}
 
 		this.gameSelect.onchange = (_) => {
-			this.gameDiv.children[0].remove();
+			this.gameDiv.firstChild?.remove();
 			this.disableButton(this.openGameButton);
 			this.gameDiv.appendChild(
 				this.generateGameIFrame(this.gameSelect.value)

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,12 @@ import SidePanel, {SIDE_PANEL_ID} from "./SidePanel";
 
 export default class ObsiDOOM extends Plugin {
 	async onload() {
+		this.addCommand({
+			id: "open",
+			name: "Open game",
+			callback: () => SidePanel.activate(this.app.workspace)
+		});
+
 		this.registerView(
 			SIDE_PANEL_ID, (leaf) => new SidePanel(leaf)
 		);

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,8 @@ export default class ObsiDOOM extends Plugin {
 			SIDE_PANEL_ID, (leaf) => new SidePanel(leaf)
 		);
 
-		await SidePanel.activate(this.app.workspace);
+		this.app.workspace.onLayoutReady(() => {
+			SidePanel.activate(this.app.workspace);
+		});
 	}
 }


### PR DESCRIPTION
This is totally separate to the [other pull request](https://github.com/twibiral/ObsiDOOM/pull/5).

- ObsiDOOM couldn't be easily reopened once closed, so I added a command to hotkey it:

![#6](https://github.com/user-attachments/assets/e985b82d-9926-4b99-8a64-e983572e386e)

- Plugin was triggering a TypeError inside `app.js` on every load, due to accessing `getRightLeaf()` before it was ready. Now it waits for `workspace.onLayoutReady()` before starting
- Fixed a bug where the `Open Game` button always opened DOOM, no matter which game was selected
- Removed the "DOOM" header above all games
- Renamed the view ID from `ObsiDOOM Side Panel` to `obsidoom`, to match the lowercase IDs used by core plugins
- Removed all console logging, since it didn't seem necessary